### PR TITLE
Add button hover animations

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -24,3 +24,12 @@ textarea {
     color: #8BE9FD; /* A light blue color */
     text-decoration: none;
 }
+
+/* Simple hover animation for buttons */
+button {
+    transition: transform 0.2s;
+}
+
+button:hover {
+    transform: scale(1.05);
+}

--- a/templates/article.html
+++ b/templates/article.html
@@ -280,11 +280,13 @@
             padding: 8px 16px;
             cursor: pointer;
             margin-left: 10px;
+            transition: background-color 0.3s, transform 0.2s;
         }
 
         button.run-button:hover, button.reset-button:hover,
         button.fullscreen-button:hover {
             background-color: #155a8a;
+            transform: scale(1.05);
         }
 
         .CodeMirror-scroll {

--- a/templates/editor.html
+++ b/templates/editor.html
@@ -62,6 +62,11 @@
             border-width: 0;
             height: 100%;
             width: 80px;
+            transition: transform 0.2s;
+        }
+
+        .btn-area button:hover {
+            transform: scale(1.05);
         }
 
         #run {

--- a/templates/mobile_editor.html
+++ b/templates/mobile_editor.html
@@ -69,6 +69,11 @@
             color: #fff;
             border: none;
             border-radius: 4px;
+            transition: transform 0.2s;
+        }
+
+        .sidebar-menu button:hover {
+            transform: scale(1.05);
         }
 
         #run-btn {

--- a/templates/mobile_sharecode.html
+++ b/templates/mobile_sharecode.html
@@ -84,6 +84,11 @@
             border-width: 0;
             border-radius: 4px;
             height: 40px;
+            transition: transform 0.2s;
+        }
+
+        #floatingMenu button:hover {
+            transform: scale(1.05);
         }
         /* 不同按钮不同背景色 */
         #save { background-color: #6dddf2; }

--- a/templates/sharecode.html
+++ b/templates/sharecode.html
@@ -60,6 +60,11 @@
             border-width: 0;
             height: 100%;
             width: 80px;
+            transition: transform 0.2s;
+        }
+
+        .btn-area button:hover {
+            transform: scale(1.05);
         }
 
         /* 原 run 按钮已移除，仅保留 save / open / share */


### PR DESCRIPTION
## Summary
- animate all buttons on hover with simple scale effect
- update article page button styles
- add hover animations to editor, share, and mobile pages

## Testing
- `python -m py_compile $(cat pyfiles.txt)`

------
https://chatgpt.com/codex/tasks/task_e_683fda98a1888321ae5e04b4cf1d8598